### PR TITLE
add charset meta tag to fix encoding in output

### DIFF
--- a/public/index.html.erb
+++ b/public/index.html.erb
@@ -1,4 +1,5 @@
 <head>
+    <meta charset="UTF-8">
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.js"></script>
     <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
     <script type="text/javascript" src="index.js"></script>


### PR DESCRIPTION
Browsers will default to ASCII and produce garbled output. Fix this by
adding a charset meta tag for UTF-8. Fixes #28.

TESTED:
eyeballed it