### PR TITLE
Corrected behavior for .gif profile pictures

### DIFF
--- a/src/analyzers/account_analyzer.rb
+++ b/src/analyzers/account_analyzer.rb
@@ -2,6 +2,9 @@ class AccountAnalyzer
     def initialize(path, params)
         @path = path
         @params = params
+        @avatar_path = Dir.glob("#{@path}/avatar.*")[0]
+        # Use globbing pattern to allow detection of multiple
+        # avatar file formats
     end
 
     def call
@@ -9,8 +12,7 @@ class AccountAnalyzer
         {
             output_files: [],
             misc_data: {
-                avatar_extension: "png", #nitro?, figure out way to detect type
-                avatar_path: "#{@path}/avatar.png" #is it always called avatar?
+                avatar_path: "#{@avatar_path}"
             },
             output_data: {
                 username: account_details['username'],


### PR DESCRIPTION
My profile picture was not correctly detected after DDP finished parsing my messages (I got the error `No such file or directory @ rb_sysopen - discord_data/account/avatar.png`). I added a globbing pattern to allow all avatar profile picture formats. Since my profile picture was `avatar.gif`, I think it's fair to assume all profile pictures will be titled with the `avatar` prefix. Also, I'm not sure of the purpose of `avatar_extension`, but removing it caused no issues for me.